### PR TITLE
added grunt-contrib-watch with a testunner.html to use livereload

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -7,11 +7,18 @@ module.exports = function(grunt) {
                     config: 'tests/intern'
                 }
             }
+        },
+        watch: {
+            all: {
+                options: { livereload: true },
+                files: ['app/*.js', 'gis/**/*.js', 'gis/**/**/*.js']
+            }
         }
     });
 
     // Loading using a local copy
     grunt.loadNpmTasks('intern');
+    grunt.loadNpmTasks('grunt-contrib-watch');
 
     // Register a test task
     grunt.registerTask('test', ['intern']);

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-	"name": "intern-esri",
-	"version": "0.1.0",
-	"devDependencies": {
-		"grunt": "*",
-		"intern": "*",
-		"intern-geezer": "*",
-		"selenium-server": "2.38.0"
-	}
+  "name": "intern-esri",
+  "version": "0.1.0",
+  "devDependencies": {
+    "grunt": "*",
+    "intern": "*",
+    "intern-geezer": "*",
+    "selenium-server": "2.38.0",
+    "grunt-contrib-watch": "~0.6.1"
+  }
 }

--- a/testrunner.html
+++ b/testrunner.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>Browser test runner</title>
+    <script src="http://localhost:35729/livereload.js"></script>
+		<script src="node_modules/intern/node_modules/dojo/dojo.js"></script>
+		<script>
+(function () {
+	var basePath = location.pathname.replace(/\/+[^\/]*$/, '/'),
+		internConfig = this.__internConfig = {
+			// For users running client.html directly, assume that the base path
+			// is two levels up (the parent of node_modules); this is most common.
+			// Users that need something special should provide an absolute module
+			// path for the config module (e.g. `/path/to/intern/config`) and
+			// then set `baseUrl` correctly in the `loader` configuration object
+			// of the config module
+			baseUrl: basePath === '/__intern/' ? '/' : (basePath + '../../'),
+			packages: [
+				{ name: 'intern', location: basePath + 'node_modules/intern' }
+			],
+			map: {
+				intern: {
+					dojo: basePath + 'node_modules/intern/node_modules/dojo',
+					chai: basePath + 'node_modules/intern/node_modules/chai/chai'
+				},
+				'*': {
+					'intern/dojo': basePath + 'node_modules/intern/node_modules/dojo'
+				}
+			}
+		};
+    console.debug(internConfig);
+	require(internConfig, [ 'intern/client' ]);
+})();
+		</script>
+	</head>
+</html>


### PR DESCRIPTION
Added `grunt-contrib-watch` and use `livereload` to reload the `testrunner.html` for every file change. This does require the user to install the livereload extension for their browser of choice. I've tested in Chrome so far and it works fine. Also copied the `client.html` file to a `testrunner.html` and adjusted the paths so the user wouldn't be required to add the livereload script in the `node_modules/intern` folder. This gives some nice feedback while developing.
