### PR TITLE
Config updates for latest grunt-esri-slurp and JSAPI v. 3.13

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
 {
-    "directory": "."
+    "directory": ".",
+    "strict-ssl": false
 }

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -9,12 +9,14 @@ module.exports = function(grunt) {
             }
         },
         esri_slurp: {
+			options: {
+                version: '3.13'
+            },
             dev: {
                 options: {
-                    version: '3.10',
-                    packageLocation: 'esri',
                     beautify: true
-                }
+                },
+                dest: 'esri'
             }
         },
         watch: {

--- a/bower.json
+++ b/bower.json
@@ -1,13 +1,13 @@
 {
   "name": "esri-slurp-example",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "dependencies": {
-    "dijit": "#1.9.1",
-    "dojo": "#1.9.1",
-    "dojox": "#1.9.1",
-    "util": "dojo-util#1.9.1",
-    "dgrid": "#0.3.14",
-    "put-selector": "#0.3.5",
+    "dijit": "#1.10.4",
+    "dojo": "#1.10.4",
+    "dojox": "#1.10.4",
+    "util": "dojo-util#1.10.4",
+    "dgrid": "#0.3.17",
+    "put-selector": "#0.3.6",
     "xstyle": "#0.1.3"
   },
   "devDependencies": {}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "grunt": "*",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-esri-slurp": "^0.6.3",
+    "grunt-esri-slurp": "^1.4.7",
     "intern": "^2.0.3",
     "selenium-server": "2.38.0"
   }


### PR DESCRIPTION
Updated package.json, grunt, and bower configurations to use more recent grunt-esri-slurp package, as well as JSAPI v. 3.13 and associated Dojo files.
